### PR TITLE
Add stylelint-order plugin and order prefs

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,14 +68,23 @@ module.exports = {
         ],
         "order": "flexible" },
 
-      { "properties": [ "opacity" ] },
+      { "properties": [
+          "transition", "transition-property", "transition-duration", "transition-timing-function", "transition-delay",
+          "transform", "transform-origin", "transform-style", "backface-visibility", "perspective", "perspective-origin"
+        ],
+        "order": "flexible" },
 
-      { "properties": [ "transition", "transition-property", "transition-duration", "transition-timing-function", "transition-delay" ] },
+      { "properties": [
+          "animation", "animation-name", "animation-duration", "animation-play-state", "animation-timing-function", "animation-delay", "animation-iteration-count", "animation-direction"
+        ],
+        "order": "flexible" },
 
-      { "properties": [ "transform", "transform-origin", "transform-style", "backface-visibility", "perspective", "perspective-origin" ] },
-      { "properties": [ "animation", "animation-name", "animation-duration", "animation-play-state", "animation-timing-function", "animation-delay", "animation-iteration-count", "animation-direction" ] },
+      { "properties": [
+          "opacity",
+          "tab-size", "counter-reset", "counter-increment", "resize", "cursor", "pointer-events", "speak", "user-select", "nav-index", "nav-up", "nav-right", "nav-down", "nav-left"
+        ],
+        "order": "flexible" },
 
-      { "properties": [ "tab-size", "counter-reset", "counter-increment", "resize", "cursor", "pointer-events", "speak", "user-select", "nav-index", "nav-up", "nav-right", "nav-down", "nav-left" ] }
     ],
     "at-rule-empty-line-before": null,
     "at-rule-name-space-after": "always",

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = {
           "text-emphasis", "text-emphasis-color", "text-emphasis-style", "text-emphasis-position",
           "vertical-align", "white-space", "word-spacing", "hyphens",
           "src"
-        ]
+        ],
         "order": "flexible" },
 
       { "properties": [

--- a/index.js
+++ b/index.js
@@ -11,11 +11,7 @@ module.exports = {
       "custom-properties",
       "dollar-variables",
       "declarations",
-      {
-        type: 'at-rule',
-        name: 'include'
-      },
-      "rules",
+      "at-rules",
       {
         type: 'at-rule',
         name: 'media'

--- a/index.js
+++ b/index.js
@@ -9,7 +9,11 @@ module.exports = {
   "rules": {
     "order/order": [
       "custom-properties",
-      "declarations"
+      "dollar-variables",
+      "custom-properties",
+      "declarations",
+      "at-rules",
+      "rules"
     ],
     "order/properties-order": [
       { "properties": [ "content", "quotes" ],

--- a/index.js
+++ b/index.js
@@ -3,9 +3,59 @@
 module.exports = {
   "extends": "stylelint-config-standard",
   "plugins": [
-    "stylelint-csstree-validator"
+    "stylelint-csstree-validator",
+    "stylelint-order"
   ],
   "rules": {
+    "order/order": [
+      "custom-properties",
+      "declarations"
+    ],
+    "order/properties-order": [
+      { "properties": [ "content", "quotes" ] },
+
+      { "properties": [ "margin", "margin-top", "margin-right", "margin-bottom", "margin-left" ] },
+      { "properties": [ "padding", "padding-top", "padding-right", "padding-bottom", "padding-left" ] },
+
+      { "properties": [ "box-sizing" ] },
+      { "properties": [ "flex", "flex-basis", "flex-direction", "flex-flow", "flex-grow", "flex-shrink", "flex-wrap", "align-content", "align-items", "align-self", "justify-content", "order" ] },
+      { "properties": [ "grid-template-columns", "grid-template-rows", "grid-template-areas", "grid-template", "grid-auto-columns", "grid-auto-rows", "grid-auto-flow", "grid", "grid-row-start", "grid-column-start", "grid-row-end", "grid-column-end", "grid-row", "grid-column", "grid-area", "grid-row-gap", "grid-column-gap", "grid-gap" ] },
+      { "properties": [ "width", "min-width", "max-width", "height", "min-height", "max-height" ] },
+      { "properties": [ "display", "visibility" ] },
+      { "properties": [ "float", "clear" ] },
+      { "properties": [ "overflow", "overflow-x", "overflow-y" ] },
+      { "properties": [ "clip", "zoom" ] },
+      { "properties": [ "columns", "column-gap", "column-fill", "column-rule", "column-span", "column-count", "column-width" ] },
+      { "properties": [ "table-layout", "empty-cells", "caption-side", "border-spacing", "border-collapse", "list-style", "list-style-position", "list-style-type", "list-style-image" ] },
+      { "properties": [ "position", "z-index", "top", "right", "bottom", "left" ] },
+
+      { "properties": [ "font", "font-family", "font-size", "font-size-adjust", "font-stretch", "font-effect", "font-style", "font-variant", "font-weight" ] },
+      { "properties": [ "font-emphasize", "font-emphasize-position", "font-emphasize-style" ] },
+      { "properties": [ "color" ] },
+      { "properties": [ "line-height", "list-style", "word-spacing" ] },
+      { "properties": [ "letter-spacing" ] },
+      { "properties": [ "text-align", "text-align-last", "text-decoration", "text-indent", "text-justify", "text-overflow", "text-overflow-ellipsis", "text-overflow-mode", "text-rendering", "text-outline", "text-shadow", "text-transform", "text-wrap", "word-wrap", "word-break" ] },
+      { "properties": [ "text-emphasis", "text-emphasis-color", "text-emphasis-style", "text-emphasis-position" ] },
+      { "properties": [ "vertical-align", "white-space", "word-spacing", "hyphens" ] },
+      { "properties": [ "src" ] },
+
+      { "properties": [ "border", "border-top", "border-right", "border-bottom", "border-left", "border-width", "border-top-width", "border-right-width", "border-bottom-width", "border-left-width" ] },
+      { "properties": [ "border-style", "border-top-style", "border-right-style", "border-bottom-style", "border-left-style" ] },
+      { "properties": [ "border-color", "border-top-color", "border-right-color", "border-bottom-color", "border-left-color" ] },
+      { "properties": [ "border-radius", "border-top-left-radius", "border-top-right-radius", "border-bottom-left-radius", "border-bottom-right-radius" ] },
+      { "properties": [ "outline", "outline-color", "outline-offset", "outline-style", "outline-width" ] },
+      { "properties": [ "stroke-width", "stroke-linecap", "stroke-dasharray", "stroke-dashoffset", "stroke" ] },
+
+      { "properties": [ "background", "background-color", "background-image", "background-repeat", "background-position", "background-size", "box-shadow", "fill" ] },
+      { "properties": [ "opacity" ] },
+
+      { "properties": [ "transition", "transition-property", "transition-duration", "transition-timing-function", "transition-delay" ] },
+
+      { "properties": [ "transform", "transform-origin", "transform-style", "backface-visibility", "perspective", "perspective-origin" ] },
+      { "properties": [ "animation", "animation-name", "animation-duration", "animation-play-state", "animation-timing-function", "animation-delay", "animation-iteration-count", "animation-direction" ] },
+
+      { "properties": [ "tab-size", "counter-reset", "counter-increment", "resize", "cursor", "pointer-events", "speak", "user-select", "nav-index", "nav-up", "nav-right", "nav-down", "nav-left" ] }
+    ],
     "at-rule-empty-line-before": null,
     "at-rule-name-space-after": "always",
     "at-rule-no-unknown": true,

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ module.exports = {
     "order/order": [
       "custom-properties",
       "dollar-variables",
-      "custom-properties",
       "declarations",
       "at-rules",
       "rules"

--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ module.exports = {
           "clip", "zoom",
           "columns", "column-gap", "column-fill", "column-rule", "column-span", "column-count", "column-width",
           "table-layout", "empty-cells", "caption-side", "border-spacing", "border-collapse",
-          "position", "z-index", "top", "right", "bottom", "left"
+          "position", "z-index", "top", "right", "bottom", "left",
+          "transform", "transform-origin", "transform-style"
         ],
         "order": "flexible" },
 
@@ -74,7 +75,7 @@ module.exports = {
 
       { "properties": [
           "transition", "transition-property", "transition-duration", "transition-timing-function", "transition-delay",
-          "transform", "transform-origin", "transform-style", "backface-visibility", "perspective", "perspective-origin"
+          "backface-visibility", "perspective", "perspective-origin"
         ],
         "order": "flexible" },
 

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
           "overflow", "overflow-x", "overflow-y",
           "clip", "zoom",
           "columns", "column-gap", "column-fill", "column-rule", "column-span", "column-count", "column-width",
-          "table-layout", "empty-cells", "caption-side", "border-spacing", "border-collapse", "list-style", "list-style-position", "list-style-type", "list-style-image",
+          "table-layout", "empty-cells", "caption-side", "border-spacing", "border-collapse",
           "position", "z-index", "top", "right", "bottom", "left"
         ],
         "order": "flexible" },
@@ -51,7 +51,8 @@ module.exports = {
           "font", "font-family", "font-size", "font-size-adjust", "font-stretch", "font-effect", "font-style", "font-variant", "font-weight",
           "font-emphasize", "font-emphasize-position", "font-emphasize-style",
           "color",
-          "line-height", "list-style", "word-spacing",
+          "list-style", "list-style-position", "list-style-type", "list-style-image",
+          "line-height", "word-spacing",
           "letter-spacing",
           "text-align", "text-align-last", "text-decoration", "text-indent", "text-justify", "text-overflow", "text-overflow-ellipsis", "text-overflow-mode", "text-rendering", "text-outline", "text-shadow", "text-transform", "text-wrap", "word-wrap", "word-break",
           "text-emphasis", "text-emphasis-color", "text-emphasis-style", "text-emphasis-position",

--- a/index.js
+++ b/index.js
@@ -11,8 +11,15 @@ module.exports = {
       "custom-properties",
       "dollar-variables",
       "declarations",
-      "at-rules",
-      "rules"
+      {
+        type: 'at-rule',
+        name: 'include'
+      },
+      "rules",
+      {
+        type: 'at-rule',
+        name: 'media'
+      }
     ],
     "order/properties-order": [
       { "properties": [ "content", "quotes" ],

--- a/index.js
+++ b/index.js
@@ -12,41 +12,62 @@ module.exports = {
       "declarations"
     ],
     "order/properties-order": [
-      { "properties": [ "content", "quotes" ] },
+      { "properties": [ "content", "quotes" ],
+        "order": "flexible" },
 
-      { "properties": [ "margin", "margin-top", "margin-right", "margin-bottom", "margin-left" ] },
-      { "properties": [ "padding", "padding-top", "padding-right", "padding-bottom", "padding-left" ] },
+      { "properties": [
+          "margin", "margin-top", "margin-right", "margin-bottom", "margin-left",
+          "padding", "padding-top", "padding-right", "padding-bottom", "padding-left",
+        ],
+        "order": "flexible" },
 
-      { "properties": [ "box-sizing" ] },
-      { "properties": [ "flex", "flex-basis", "flex-direction", "flex-flow", "flex-grow", "flex-shrink", "flex-wrap", "align-content", "align-items", "align-self", "justify-content", "order" ] },
-      { "properties": [ "grid-template-columns", "grid-template-rows", "grid-template-areas", "grid-template", "grid-auto-columns", "grid-auto-rows", "grid-auto-flow", "grid", "grid-row-start", "grid-column-start", "grid-row-end", "grid-column-end", "grid-row", "grid-column", "grid-area", "grid-row-gap", "grid-column-gap", "grid-gap" ] },
-      { "properties": [ "width", "min-width", "max-width", "height", "min-height", "max-height" ] },
-      { "properties": [ "display", "visibility" ] },
-      { "properties": [ "float", "clear" ] },
-      { "properties": [ "overflow", "overflow-x", "overflow-y" ] },
-      { "properties": [ "clip", "zoom" ] },
-      { "properties": [ "columns", "column-gap", "column-fill", "column-rule", "column-span", "column-count", "column-width" ] },
-      { "properties": [ "table-layout", "empty-cells", "caption-side", "border-spacing", "border-collapse", "list-style", "list-style-position", "list-style-type", "list-style-image" ] },
-      { "properties": [ "position", "z-index", "top", "right", "bottom", "left" ] },
+      { "properties": [
+          "width", "min-width", "max-width", "height", "min-height", "max-height",
+        ],
+        "order": "flexible" },
 
-      { "properties": [ "font", "font-family", "font-size", "font-size-adjust", "font-stretch", "font-effect", "font-style", "font-variant", "font-weight" ] },
-      { "properties": [ "font-emphasize", "font-emphasize-position", "font-emphasize-style" ] },
-      { "properties": [ "color" ] },
-      { "properties": [ "line-height", "list-style", "word-spacing" ] },
-      { "properties": [ "letter-spacing" ] },
-      { "properties": [ "text-align", "text-align-last", "text-decoration", "text-indent", "text-justify", "text-overflow", "text-overflow-ellipsis", "text-overflow-mode", "text-rendering", "text-outline", "text-shadow", "text-transform", "text-wrap", "word-wrap", "word-break" ] },
-      { "properties": [ "text-emphasis", "text-emphasis-color", "text-emphasis-style", "text-emphasis-position" ] },
-      { "properties": [ "vertical-align", "white-space", "word-spacing", "hyphens" ] },
-      { "properties": [ "src" ] },
+      { "properties": [
+          "display", "visibility"
+        ],
+        "order": "flexible" },
 
-      { "properties": [ "border", "border-top", "border-right", "border-bottom", "border-left", "border-width", "border-top-width", "border-right-width", "border-bottom-width", "border-left-width" ] },
-      { "properties": [ "border-style", "border-top-style", "border-right-style", "border-bottom-style", "border-left-style" ] },
-      { "properties": [ "border-color", "border-top-color", "border-right-color", "border-bottom-color", "border-left-color" ] },
-      { "properties": [ "border-radius", "border-top-left-radius", "border-top-right-radius", "border-bottom-left-radius", "border-bottom-right-radius" ] },
-      { "properties": [ "outline", "outline-color", "outline-offset", "outline-style", "outline-width" ] },
-      { "properties": [ "stroke-width", "stroke-linecap", "stroke-dasharray", "stroke-dashoffset", "stroke" ] },
+      { "properties": [
+          "box-sizing",
+          "grid-template-columns", "grid-template-rows", "grid-template-areas", "grid-template", "grid-auto-columns", "grid-auto-rows", "grid-auto-flow", "grid", "grid-row-start", "grid-column-start", "grid-row-end", "grid-column-end", "grid-row", "grid-column", "grid-area", "grid-row-gap", "grid-column-gap", "grid-gap",
+          "flex", "flex-basis", "flex-direction", "flex-flow", "flex-grow", "flex-shrink", "flex-wrap", "align-content", "align-items", "align-self", "justify-content", "order",
+          "float", "clear",
+          "overflow", "overflow-x", "overflow-y",
+          "clip", "zoom",
+          "columns", "column-gap", "column-fill", "column-rule", "column-span", "column-count", "column-width",
+          "table-layout", "empty-cells", "caption-side", "border-spacing", "border-collapse", "list-style", "list-style-position", "list-style-type", "list-style-image",
+          "position", "z-index", "top", "right", "bottom", "left"
+        ],
+        "order": "flexible" },
 
-      { "properties": [ "background", "background-color", "background-image", "background-repeat", "background-position", "background-size", "box-shadow", "fill" ] },
+      { "properties": [
+          "font", "font-family", "font-size", "font-size-adjust", "font-stretch", "font-effect", "font-style", "font-variant", "font-weight",
+          "font-emphasize", "font-emphasize-position", "font-emphasize-style",
+          "color",
+          "line-height", "list-style", "word-spacing",
+          "letter-spacing",
+          "text-align", "text-align-last", "text-decoration", "text-indent", "text-justify", "text-overflow", "text-overflow-ellipsis", "text-overflow-mode", "text-rendering", "text-outline", "text-shadow", "text-transform", "text-wrap", "word-wrap", "word-break",
+          "text-emphasis", "text-emphasis-color", "text-emphasis-style", "text-emphasis-position",
+          "vertical-align", "white-space", "word-spacing", "hyphens",
+          "src"
+        ]
+        "order": "flexible" },
+
+      { "properties": [
+          "border", "border-top", "border-right", "border-bottom", "border-left", "border-width", "border-top-width", "border-right-width", "border-bottom-width", "border-left-width",
+          "border-style", "border-top-style", "border-right-style", "border-bottom-style", "border-left-style",
+          "border-color", "border-top-color", "border-right-color", "border-bottom-color", "border-left-color",
+          "border-radius", "border-top-left-radius", "border-top-right-radius", "border-bottom-left-radius", "border-bottom-right-radius",
+          "background", "background-color", "background-image", "background-repeat", "background-position", "background-size", "box-shadow", "fill",
+          "outline", "outline-color", "outline-offset", "outline-style", "outline-width",
+          "stroke-width", "stroke-linecap", "stroke-dasharray", "stroke-dashoffset", "stroke"
+        ],
+        "order": "flexible" },
+
       { "properties": [ "opacity" ] },
 
       { "properties": [ "transition", "transition-property", "transition-duration", "transition-timing-function", "transition-delay" ] },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-narwin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Stylelint configuration used by DockYard",
   "repository": "https://github.com/dockyard/stylelint-config-narwin",
   "keywords": [
@@ -23,6 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "stylelint": "~8.2.0",
-    "stylelint-csstree-validator": "^1.2.0"
+    "stylelint-csstree-validator": "^1.2.0",
+    "stylelint-order": "^0.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-narwin",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Stylelint configuration used by DockYard",
   "repository": "https://github.com/dockyard/stylelint-config-narwin",
   "keywords": [


### PR DESCRIPTION
Add stylelint-order plugin and property sort order based on [the styleguide](https://github.com/dockyard/styleguides/blob/master/ux-dev/css.md)

### To test:
In a project that uses `stylelint-config-narwin`, change the version number in `package.json` to this:

```
"stylelint-config-narwin": "git+ssh://git@github.com:DockYard/stylelint-config-narwin.git#jsit/stylelint-order"
```

then `npm i` to get the version from this branch.