### PR TITLE
Fixes #11 Set `declaration-colon-space-after` to `always-single-line`

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = {
     "declaration-block-semicolon-space-after": null,
     "declaration-block-semicolon-space-before": null,
     "declaration-colon-newline-after": null,
-    "declaration-colon-space-after": "always",
+    "declaration-colon-space-after": "always-single-line",
     "declaration-empty-line-before": "never",
     "font-family-name-quotes": "always-unless-keyword",
     "font-weight-notation": "numeric",


### PR DESCRIPTION
Fixes #11 
It's commonplace to use multi-line values for some CSS attributes, such as `grid-template-areas`

https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas

Currently `stylelint-config-narwin` is throwing `Expected single space after ":"` errors for `declaration-colon-space-after`. 
```sass
grid-template-areas:
      "header"
      "main"
      "sidebar"
      "footer";
```
This is compounded by the fact that most text editors will automatically remove the trailing space after line-ending `:`s. Thus, it's often not possible to save a file with the expected trailing space on common multi-line attributes.

To fix this, we are setting [`declaration-colon-space-after`](https://stylelint.io/user-guide/rules/declaration-colon-space-after/#always-single-line) to `always-single-line`.